### PR TITLE
fix(cookie-block): 修正正式環境無法使用 cookie 問題

### DIFF
--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -10,6 +10,7 @@ const generateToken = (res: Response, userId: string) => {
   res.cookie('jwt', token, {
     httpOnly: true,
     secure: process.env.NODE_ENV !== 'development',
+    domain: process.env.NODE_ENV !== 'development' ? process.env.FRONT_END_URL?.replace('https://', '.') : undefined,
     sameSite: 'strict',
     maxAge: 60 * 60 * 1000
   })


### PR DESCRIPTION
問題:

1. API response header 上的 set-cookie 會出現 "This attempt to set a cookie via a set-cookie header was blocked" 的警告，瀏覽器無法使用 cookie

原因:

1. 目前推測與 cookie domain 有關

調整:

1. 在 res.cookie 判斷正式環境時，domain 要是前端的網址