### PR TITLE
fix(cookie-block-2): 修正正式環境無法使用 cookie 問題

### DIFF
--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -10,7 +10,7 @@ const generateToken = (res: Response, userId: string) => {
   res.cookie('jwt', token, {
     httpOnly: true,
     secure: process.env.NODE_ENV !== 'development',
-    domain: process.env.FRONT_END_URL?.includes('https://') ? process.env.FRONT_END_URL?.replace('https://', '.') : undefined,
+    domain: process.env.FRONT_END_URL?.includes('https://') ? process.env.FRONT_END_URL?.replace('https://', '') : undefined,
     sameSite: 'strict',
     maxAge: 60 * 60 * 1000
   })


### PR DESCRIPTION
問題:

1. 接續 fix(cookie-block-1)，目前 set-cookie 報錯變成 " This Set-Cookie was blocked because its Domain attribute was invalid with regards to the current host url."

原因:

1. 推測 domain 設定錯誤

調整:

1. 移除 domain 前面的 "."