### PR TITLE
fix(cookie-block-3): 修正正式環境無法使用 cookie 問題

### DIFF
--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -9,9 +9,8 @@ const generateToken = (res: Response, userId: string) => {
 
   res.cookie('jwt', token, {
     httpOnly: true,
-    secure: process.env.NODE_ENV !== 'development',
-    domain: process.env.FRONT_END_URL?.includes('https://') ? process.env.FRONT_END_URL?.replace('https://', '') : undefined,
-    sameSite: 'strict',
+    secure: process.env.FRONT_END_URL?.includes('https://'),
+    sameSite: process.env.FRONT_END_URL?.includes('https://') ? 'none' : 'strict',
     maxAge: 60 * 60 * 1000
   })
 }


### PR DESCRIPTION
問題:

1. 接續 fix(cookie-block-2)

原因:

1. 參考 https://community.render.com/t/setting-samesite-attribute-for-cookies-from-different-render-domains/16868 指出 onrender.com 在 sameSite 為 strict 時不能設為 domain

調整:

1. 調整正式環境的 sameSite=none，secure=true

參考 https://developers.google.com/search/blog/2020/01/get-ready-for-new-samesitenone-secure?hl=zh-tw