### PR TITLE
fix(cookie-block-4): 修正正式環境無法使用 cookie 問題

### DIFF
--- a/src/controllers/authController.ts
+++ b/src/controllers/authController.ts
@@ -41,14 +41,15 @@ const registerUser = async (req: Request, res: Response, next: NextFunction) => 
     name, email, password
   })
   if (user) {
-    generateToken(res, user._id)
+    const token = generateToken(res, user._id)
     res.status(201).json({
       status: true,
       message: '註冊成功',
       data: {
         id: user._id,
         name: user.name,
-        email: user.email
+        email: user.email,
+        token
       }
     })
   } else {
@@ -61,14 +62,15 @@ const authenticateUser = async (req: Request, res: Response) => {
   const user = await User.findOne({ email })
 
   if (user && (await user.comparePassword(password))) {
-    generateToken(res, user._id)
+    const token = generateToken(res, user._id)
     res.status(201).json({
       status: true,
       message: '登入成功',
       data: {
         id: user._id,
         name: user.name,
-        email: user.email
+        email: user.email,
+        token
       }
     })
   } else {

--- a/src/middleware/authMiddleware.ts
+++ b/src/middleware/authMiddleware.ts
@@ -7,7 +7,7 @@ import { AuthenticationError } from './errorMiddleware'
 const authenticate = asyncHandler(
   async (req: Request, res: Response, next: NextFunction) => {
     try {
-      let token = req.cookies.jwt
+      let token = req.headers?.authorization?.split('Bearer ')?.[1]
 
       if (!token) {
         throw new AuthenticationError(401, 'Token not found')

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -7,16 +7,11 @@ const generateToken = (res: Response, userId: string) => {
     expiresIn: '1h'
   })
 
-  res.cookie('jwt', token, {
-    httpOnly: true,
-    secure: process.env.FRONT_END_URL?.includes('https://'),
-    sameSite: process.env.FRONT_END_URL?.includes('https://') ? 'none' : 'strict',
-    maxAge: 60 * 60 * 1000
-  })
+  return token
 }
 
 const clearToken = (res: Response) => {
-  res.cookie('jwt', '', {
+  res.cookie('token', '', {
     httpOnly: true,
     expires: new Date(0)
   })


### PR DESCRIPTION
問題:

1. 接續 fix(cookie-block-3)

原因:

1. 經確認，render 服務無法設定 cookie domain (public suffix)

2. google 也會警告 sameSite none;secure 的 cookie 讓瀏覽器無法使用

調整:

1. 改成將 token 放在 body 裡傳給前端把 token 設定在 cookie，並且接收來自 request header 的 authorization token