### PR TITLE
Feat/issue53

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "moment": "^2.30.1",
     "mongoose": "^8.3.2",
     "multer": "^1.4.5-lts.1",
+    "socket.io": "^4.7.5",
     "swagger-autogen": "^2.23.7",
     "swagger-ui-express": "^5.0.0",
     "uuid": "^9.0.1",

--- a/src/connections/socket.ts
+++ b/src/connections/socket.ts
@@ -3,8 +3,14 @@ import { Server } from 'socket.io'
 
 let io: any
 export function connectSocketIo (server: HttpServer) {
-  io = new Server(server)
-  io.on('connection', socket => {
+  io = new Server(server, {
+    cors: {
+      origin: 'http://localhost:4000',
+      methods: ['GET', 'POST'],
+      credentials: true
+    }
+  })
+  io.on('connection', (socket: any) => {
     console.log('Client connected')
   })
 }

--- a/src/connections/socket.ts
+++ b/src/connections/socket.ts
@@ -1,0 +1,16 @@
+import { Server as HttpServer } from 'http'
+import { Server } from 'socket.io'
+
+let io: any
+export function connectSocketIo (server: HttpServer) {
+  io = new Server(server)
+  io.on('connection', socket => {
+    console.log('Client connected')
+  })
+}
+export function getSocektIo () {
+  if (!io) {
+    throw new Error('Socket.io is not initialized')
+  }
+  return io
+}

--- a/src/connections/socket.ts
+++ b/src/connections/socket.ts
@@ -1,8 +1,10 @@
 import { Server as HttpServer } from 'http'
-import { Server } from 'socket.io'
+import { Server, Socket } from 'socket.io'
 
-let io: any
-export function connectSocketIo (server: HttpServer) {
+let onlineUsers: { [userId: string]: string } = {}
+
+let io: Server
+export const connectSocketIo = (server: HttpServer) => {
   io = new Server(server, {
     cors: {
       origin: 'http://localhost:4000',
@@ -10,13 +12,21 @@ export function connectSocketIo (server: HttpServer) {
       credentials: true
     }
   })
-  io.on('connection', (socket: any) => {
-    console.log('Client connected')
+  io.on('connection', (socket: Socket) => {
+    console.log('SocketIo Client connected')
+
+    const userId = socket.handshake.query.userId as string
+    onlineUsers[userId] = socket.id
+
+    socket.on('disconnect', () => {
+      delete onlineUsers[userId]
+    })
   })
 }
-export function getSocektIo () {
+export const getSocektIo = () => {
   if (!io) {
-    throw new Error('Socket.io is not initialized')
+    throw new Error('SocketIo 發生錯誤')
   }
   return io
 }
+export const getOnlineUsers = () => onlineUsers

--- a/src/controllers/adminController.ts
+++ b/src/controllers/adminController.ts
@@ -5,26 +5,49 @@ import { appError } from '../middleware/errorMiddleware'
 import { apiState } from '../utils/apiState'
 import { getSocektIo } from '../connections/socket'
 import News from '../models/News'
+import Notice from '../models/Notice'
 
 // 新增文章
 const createNewsArticle = catchAsync(async (req: Request, res: Response, next: NextFunction) => {
-  const { title, content, publishedAt, source, tags, articleId } = req.body
-  if (!title || !content || !publishedAt || !source || !tags || !articleId) {
+  const { articleId, topic, editor, title, publishedAt, image, imageDescribe, content, source } = req.body
+  const idPattern = /^N-\d+$/
+  const datePattern = /^(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2})$/
+  if (!topic || !editor || !title || !content ||
+    !datePattern.test(publishedAt) || !idPattern.test(articleId)) {
     return appError(apiState.DATA_MISSING, next)
   }
   const data = await News.create({
+    articleId,
+    topic,
+    editor,
     title,
-    content,
     publishedAt,
-    source,
-    tags,
-    articleId
+    imageDescribe,
+    image,
+    content,
+    source
   })
-  // getSocektIo().emit('new-news', {
-  //   action: 'create',
-  //   data
-  // })
-  appSuccess({ res, data, message: '新增文章成功' })
+  createNotice(data)
+  appSuccess({ res, message: '新增新聞文章成功' })
 })
+
+// 新增通知訊息
+const createNotice = async (data: any) => {
+  try {
+    await Notice.create({
+      articleId: data.articleId,
+      title: data.title,
+      topic: data.topic,
+      image: data.image,
+      publishedAt: data.publishedAt
+    })
+    getSocektIo().emit('notice', {
+      action: 'create',
+      receive: true
+    })
+  } catch (error) {
+    throw new Error('新增通知訊息失敗')
+  }
+}
 
 export { createNewsArticle }

--- a/src/controllers/adminController.ts
+++ b/src/controllers/adminController.ts
@@ -3,12 +3,63 @@ import { catchAsync } from '../utils/catchAsync'
 import { appSuccess } from '../utils/appSuccess'
 import { appError } from '../middleware/errorMiddleware'
 import { apiState } from '../utils/apiState'
-import { getSocektIo } from '../connections/socket'
-import News from '../models/News'
-import Notice from '../models/Notice'
-import User from '../models/User'
+import { getSocektIo, getOnlineUsers } from '../connections/socket'
+import User, { IUser } from '../models/User'
+import News, { INews } from '../models/News'
+import Notice, { INotice } from '../models/Notice'
 
-// 新增文章
+// ! fixed: users 只接收 userId 的陣列
+// 發布通知
+const postNotice = async (users: IUser[], title?: string) => {
+  users.forEach((user: IUser) => {
+    const socketId = getOnlineUsers()[user._id]
+    if (socketId) {
+      getSocektIo().emit('notice', {
+        action: 'create',
+        receive: true,
+        title
+      })
+    }
+  })
+}
+
+// 使用者系統通知
+const createSystemNotice = async (data: INotice, userId: string) => {
+  const newNotice = await Notice.create({
+    articleId: data.articleId,
+    title: data.title,
+    content: data.content,
+    publishedAt: data.publishedAt
+  })
+
+  await User.findByIdAndUpdate(userId, {
+    $addToSet: { notices: { noticeId: newNotice._id } }
+  })
+  // postNotice(users, newNotice.title)
+}
+
+// 使用者追蹤通知
+const postFollowNotice = async (data: INews) => {
+  const newNotice = await Notice.create({
+    articleId: data.articleId,
+    topic: data.topic,
+    title: data.title,
+    content: data.content,
+    publishedAt: data.publishedAt
+  })
+
+  const users = await User.find({ follows: { $in: data.topic } })
+
+  const updates = users.map((user: IUser) => user._id)
+
+  await User.updateMany(
+    { _id: { $in: updates } },
+    { $addToSet: { notices: { noticeId: newNotice._id } } }
+  )
+  postNotice(users, newNotice.title)
+}
+
+// 新增新聞文章
 const createNewsArticle = catchAsync(async (req: Request, res: Response, next: NextFunction) => {
   const { articleId, topic, editor, title, publishedAt, image, imageDescribe, content, source } = req.body
   const idPattern = /^N-\d+$/
@@ -28,37 +79,52 @@ const createNewsArticle = catchAsync(async (req: Request, res: Response, next: N
     content,
     source
   })
-  createNotice(data)
+  postFollowNotice(data)
   appSuccess({ res, message: '新增新聞文章成功' })
 })
 
-// 新增通知訊息
-const createNotice = async (data: any) => {
-  try {
-    const newNotice = await Notice.create({
-      articleId: data.articleId,
-      title: data.title,
-      topic: data.topic,
-      image: data.image,
-      publishedAt: data.publishedAt
-    })
+// 取得所有通知訊息
+const getNoticeList = catchAsync(async (req: Request, res: Response, next: NextFunction) => {
+  const { pageIndex, pageSize } = req.query
 
-    const users = await User.find({ follows: { $in: data.topic } })
+  const pageIndexNumber = pageIndex !== undefined && pageIndex !== ''
+    ? parseInt(pageIndex as string)
+    : 1
 
-    const updates = users.map(user => user._id)
+  const pageSizeNumber = pageSize !== undefined && pageSize !== ''
+    ? parseInt(pageSize as string)
+    : 10
 
-    await User.updateMany(
-      { _id: { $in: updates } },
-      { $addToSet: { notices: { notice: newNotice._id } } }
-    )
+  const [totalElements, notices] = await Promise.all([
+    Notice.countDocuments(),
+    Notice.find()
+      .sort({ publishedAt: -1 })
+      .skip((pageIndexNumber - 1) * pageSizeNumber)
+      .limit(pageSizeNumber)
+      .lean()
+      .then(notices =>
+        notices.map(notice => ({
+          ...notice,
+          id: notice._id,
+          _id: undefined
+        }))
+      )
+  ])
 
-    getSocektIo().emit('notice', {
-      action: 'create',
-      receive: true
-    })
-  } catch (error) {
-    throw new Error('新增通知訊息失敗')
+  const firstPage = pageIndexNumber === 1
+  const lastPage = totalElements <= pageIndexNumber * pageSizeNumber
+  const empty = totalElements === 0
+  const totalPages = Math.ceil(totalElements / pageSizeNumber)
+  let data = {
+    notices,
+    firstPage,
+    lastPage,
+    empty,
+    totalElements,
+    totalPages,
+    targetPage: pageIndexNumber
   }
-}
+  appSuccess({ res, data, message: '取得通知訊息列表成功' })
+})
 
-export { createNewsArticle }
+export { createNewsArticle, getNoticeList }

--- a/src/controllers/adminController.ts
+++ b/src/controllers/adminController.ts
@@ -1,0 +1,30 @@
+import { NextFunction, Request, Response } from 'express'
+import { catchAsync } from '../utils/catchAsync'
+import { appSuccess } from '../utils/appSuccess'
+import { appError } from '../middleware/errorMiddleware'
+import { apiState } from '../utils/apiState'
+import { getSocektIo } from '../connections/socket'
+import News from '../models/News'
+
+// 新增文章
+const createNewsArticle = catchAsync(async (req: Request, res: Response, next: NextFunction) => {
+  const { title, content, publishedAt, source, tags, articleId } = req.body
+  if (!title || !content || !publishedAt || !source || !tags || !articleId) {
+    return appError(apiState.DATA_MISSING, next)
+  }
+  const data = await News.create({
+    title,
+    content,
+    publishedAt,
+    source,
+    tags,
+    articleId
+  })
+  // getSocektIo().emit('new-news', {
+  //   action: 'create',
+  //   data
+  // })
+  appSuccess({ res, data, message: '新增文章成功' })
+})
+
+export { createNewsArticle }

--- a/src/controllers/guestController.ts
+++ b/src/controllers/guestController.ts
@@ -48,29 +48,33 @@ const getAllMagazine = catchAsync(async (req: Request, res: Response) => {
 
 // 取得雜誌文章列表
 const getMagazineList = catchAsync(async (req: Request, res: Response) => {
-  const query = req.query
-  const articlesPerPage = 6
+  const { pageIndex, pageSize, category } = req.query
 
-  const category = query.category !== undefined && query.category !== ''
-    ? { 'source.name': query.category }
+  const categoryType = category !== undefined && category !== ''
+    ? { 'source.name': category }
     : { articleId: /M-/ }
-  const pageIndex = query.pageIndex !== undefined && query.pageIndex !== ''
-    ? parseInt(query.pageIndex as string)
+
+  const pageIndexNumber = pageIndex !== undefined && pageIndex !== ''
+    ? parseInt(pageIndex as string)
     : 1
 
+  const pageSizeNumber = pageSize !== undefined && pageSize !== ''
+    ? parseInt(pageSize as string)
+    : 10
+
   const [totalElements, articles] = await Promise.all([
-    News.countDocuments({ ...category }),
-    News.find({ ...category })
+    News.countDocuments({ ...categoryType }),
+    News.find({ ...categoryType })
       .select('-_id -content')
       .sort({ publishedAt: -1 })
-      .skip((pageIndex - 1) * articlesPerPage)
-      .limit(articlesPerPage)
+      .skip((pageIndexNumber - 1) * pageSizeNumber)
+      .limit(pageSizeNumber)
   ])
 
-  const firstPage = pageIndex === 1
-  const lastPage = totalElements <= pageIndex * articlesPerPage
+  const firstPage = pageIndexNumber === 1
+  const lastPage = totalElements <= pageIndexNumber * pageSizeNumber
   const empty = totalElements === 0
-  const totalPages = Math.ceil(totalElements / articlesPerPage)
+  const totalPages = Math.ceil(totalElements / pageSizeNumber)
   let data = {
     articles,
     firstPage,
@@ -78,7 +82,7 @@ const getMagazineList = catchAsync(async (req: Request, res: Response) => {
     empty,
     totalElements,
     totalPages,
-    targetPage: pageIndex
+    targetPage: pageIndexNumber
   }
   appSuccess({ res, data, message: '取得文章列表成功' })
 })

--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -261,6 +261,7 @@ const getUserNoticeList = catchAsync(async (req: Request, res: Response, next: N
       })
     )
 
+  const unreadElements = notices.filter(n => !n.read).length
   const totalElements = noticeIds.length
   const firstPage = pageIndexNumber === 1
   const lastPage = totalElements <= pageIndexNumber * pageSizeNumber
@@ -268,6 +269,7 @@ const getUserNoticeList = catchAsync(async (req: Request, res: Response, next: N
   const totalPages = Math.ceil(totalElements / pageSizeNumber)
   let data = {
     notices,
+    unreadElements,
     firstPage,
     lastPage,
     empty,

--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -159,7 +159,7 @@ const addArticleCollect = catchAsync(async (req: Request, res: Response, next: N
   const article = await News.findOne({ articleId })
   if (!article) return appError(apiState.DATA_NOT_FOUND, next)
 
-  await User.findByIdAndUpdate({ _id: userId }, {
+  await User.findByIdAndUpdate(userId, {
     $addToSet: { collects: articleId }
   }, { runValidators: true })
 
@@ -174,7 +174,7 @@ const deleteArticleCollect = catchAsync(async (req: Request, res: Response, next
   const article = await News.findOne({ articleId })
   if (!article) return appError(apiState.DATA_NOT_FOUND, next)
 
-  await User.findByIdAndUpdate({ _id: userId }, {
+  await User.findByIdAndUpdate(userId, {
     $pull: { collects: articleId }
   }, { runValidators: true })
 
@@ -201,7 +201,7 @@ const addArticleFollow = catchAsync(async (req: Request, res: Response, next: Ne
     return appError({ statusCode: 400, message: '主題不存在' }, next)
   }
 
-  await User.findByIdAndUpdate({ _id: userId }, {
+  await User.findByIdAndUpdate(userId, {
     $addToSet: { follows: topic }
   }, { runValidators: true })
 
@@ -217,17 +217,86 @@ const deleteArticleFollow = catchAsync(async (req: Request, res: Response, next:
     return appError({ statusCode: 400, message: '主題不存在' }, next)
   }
 
-  await User.findByIdAndUpdate({ _id: userId }, {
+  await User.findByIdAndUpdate(userId, {
     $pull: { follows: topic }
   }, { runValidators: true })
 
   appSuccess({ res, message: '取消追蹤主題成功' })
 })
 
-// 取得通知訊息列表
-const getNoticeList = catchAsync(async (req: Request, res: Response, next: NextFunction) => {
-  const data = await Notice.find().sort({ publishedAt: -1 })
+// 取得會員通知訊息列表
+const getUserNoticeList = catchAsync(async (req: Request, res: Response, next: NextFunction) => {
+  const userId = req.user?._id
+  const { pageIndex, pageSize } = req.query
+
+  const pageIndexNumber = pageIndex !== undefined && pageIndex !== ''
+    ? parseInt(pageIndex as string)
+    : 1
+
+  const pageSizeNumber = pageSize !== undefined && pageSize !== ''
+    ? parseInt(pageSize as string)
+    : 10
+
+  const user = await User.findById(userId)
+  if (!user) return appError(apiState.DATA_NOT_FOUND, next)
+
+  const noticeIds = user.notices.map(n => n.noticeId)
+  const notices = await Notice.find({ _id: { $in: noticeIds } })
+    .sort({ publishedAt: -1 })
+    .skip((pageIndexNumber - 1) * pageSizeNumber)
+    .limit(pageSizeNumber)
+    .lean()
+    .then(notices =>
+      notices.map(notice => {
+        const noticeInfo = user.notices.find(n => n.noticeId.toString() === notice._id.toString())
+        return {
+          ...notice,
+          id: notice._id,
+          read: noticeInfo ? noticeInfo.read : false,
+          _id: undefined
+        }
+      })
+    )
+
+  const totalElements = noticeIds.length
+  const firstPage = pageIndexNumber === 1
+  const lastPage = totalElements <= pageIndexNumber * pageSizeNumber
+  const empty = totalElements === 0
+  const totalPages = Math.ceil(totalElements / pageSizeNumber)
+  let data = {
+    notices,
+    firstPage,
+    lastPage,
+    empty,
+    totalElements,
+    totalPages,
+    targetPage: pageIndexNumber
+  }
   appSuccess({ res, data, message: '取得通知訊息列表成功' })
+})
+
+// 會員已閱讀此通知訊息
+const updateUserNoticeRead = catchAsync(async (req: Request, res: Response, next: NextFunction) => {
+  const userId = req.user?._id
+  const { noticeId } = req.params
+
+  await User.updateOne(
+    { _id: userId, 'notices.noticeId': noticeId },
+    { $set: { 'notices.$.read': true } }
+  )
+
+  appSuccess({ res, message: '已閱讀通知訊息成功' })
+})
+
+// 刪除會員所有通知訊息
+const deleteUserAllNotice = catchAsync(async (req: Request, res: Response, next: NextFunction) => {
+  const userId = req.user?._id
+
+  const data = await User.findByIdAndUpdate(userId, {
+    notices: []
+  }, { new: true, runValidators: true }).select('-_id notices')
+
+  appSuccess({ res, data, message: '刪除所有通知訊息成功' })
 })
 
 export {
@@ -235,5 +304,6 @@ export {
   updateUserInfo, getUserCollectList,
   addArticleCollect, deleteArticleCollect,
   getUserFollowList, addArticleFollow,
-  deleteArticleFollow, getNoticeList
+  deleteArticleFollow, getUserNoticeList,
+  deleteUserAllNotice, updateUserNoticeRead
 }

--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -1,6 +1,7 @@
 import { NextFunction, Request, Response } from 'express'
 import User from '../models/User'
 import News from '../models/News'
+import Notice from '../models/Notice'
 import bcrypt from 'bcryptjs'
 import validator from 'validator'
 import { catchAsync } from '../utils/catchAsync'
@@ -223,10 +224,16 @@ const deleteArticleFollow = catchAsync(async (req: Request, res: Response, next:
   appSuccess({ res, message: '取消追蹤主題成功' })
 })
 
+// 取得通知訊息列表
+const getNoticeList = catchAsync(async (req: Request, res: Response, next: NextFunction) => {
+  const data = await Notice.find().sort({ publishedAt: -1 })
+  appSuccess({ res, data, message: '取得通知訊息列表成功' })
+})
+
 export {
   getUser, updatePassword, getUserInfo,
   updateUserInfo, getUserCollectList,
   addArticleCollect, deleteArticleCollect,
   getUserFollowList, addArticleFollow,
-  deleteArticleFollow
+  deleteArticleFollow, getNoticeList
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import cookieParser from 'cookie-parser'
 import swaggerUi from 'swagger-ui-express'
 import swaggerFile from '../swagger_output.json'
 import routes from './routes'
+import { connectSocketIo } from './connections/socket'
 
 // 遠端資料庫連線
 import connectUserDB from './connections/userDB'
@@ -67,6 +68,7 @@ connectUserDB()
 
 // 啟動server
 const port = process.env.PORT || 3000
-app.listen(port, () => {
+const server = app.listen(port, () => {
   console.log(`Server is running on port ${port}`)
 })
+connectSocketIo(server)

--- a/src/models/News.ts
+++ b/src/models/News.ts
@@ -40,7 +40,7 @@ const newsSchema = new Schema<INews>(
     },
     imageDescribe: {
       type: String,
-      required: true
+      default: ''
     },
     image: {
       type: String,
@@ -53,12 +53,11 @@ const newsSchema = new Schema<INews>(
     source: {
       name: {
         type: String,
-        required: true
+        default: ''
       },
       url: {
         type: String,
-        default: '',
-        required: true
+        default: ''
       }
     }
   },

--- a/src/models/Notice.ts
+++ b/src/models/Notice.ts
@@ -4,16 +4,16 @@ export interface INotice extends Document {
   articleId: string,
   topic: string[],
   title: string,
-  publishedAt: string,
-  image: string
+  content: string,
+  publishedAt: string
 }
 
 const noticeSchema = new Schema<INotice>(
   {
-    articleId: { type: String, required: true, unique: true },
+    articleId: { type: String, default: '' },
+    topic: { type: [String], default: [] },
     title: { type: String, required: true },
-    topic: { type: [String], required: true },
-    image: { type: String, default: '' },
+    content: { type: String, required: true },
     publishedAt: { type: String, required: true }
   },
   {

--- a/src/models/Notice.ts
+++ b/src/models/Notice.ts
@@ -1,0 +1,26 @@
+import mongoose, { Document, Schema } from 'mongoose'
+
+export interface INotice extends Document {
+  articleId: string,
+  topic: string[],
+  title: string,
+  publishedAt: string,
+  image: string
+}
+
+const noticeSchema = new Schema<INotice>(
+  {
+    articleId: { type: String, required: true, unique: true },
+    title: { type: String, required: true },
+    topic: { type: [String], required: true },
+    image: { type: String, default: '' },
+    publishedAt: { type: String, required: true }
+  },
+  {
+    versionKey: false
+  }
+)
+
+const Notice = mongoose.model('Notice', noticeSchema)
+
+export default Notice

--- a/src/models/Notice.ts
+++ b/src/models/Notice.ts
@@ -14,7 +14,7 @@ const noticeSchema = new Schema<INotice>(
     topic: { type: [String], default: [] },
     title: { type: String, required: true },
     content: { type: String, required: true },
-    publishedAt: { type: String, required: true }
+    publishedAt: { type: String, default: '' }
   },
   {
     versionKey: false

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -14,6 +14,7 @@ export interface IUser extends Document {
   gender: string;
   collects: string[];
   follows: string[];
+  notices: string[];
   comparePassword: (enteredPassword: string) => Promise<boolean>;
 }
 
@@ -29,7 +30,13 @@ const userSchema = new Schema<IUser>(
     birthday: { type: String },
     gender: { type: String, default: '1', enum: ['0', '1'] },
     collects: [{ type: String, ref: 'News' }],
-    follows: [{ type: String, ref: 'News' }]
+    follows: [{ type: String, ref: 'News' }],
+    notices: [
+      {
+        notice: { type: String, ref: 'Notice' },
+        read: { type: Boolean, default: false }
+      }
+    ]
   },
   {
     versionKey: false

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -14,7 +14,10 @@ export interface IUser extends Document {
   gender: string;
   collects: string[];
   follows: string[];
-  notices: string[];
+  notices: {
+    noticeId: string;
+    read: boolean;
+  }[];
   comparePassword: (enteredPassword: string) => Promise<boolean>;
 }
 
@@ -33,7 +36,7 @@ const userSchema = new Schema<IUser>(
     follows: [{ type: String, ref: 'News' }],
     notices: [
       {
-        notice: { type: String, ref: 'Notice' },
+        noticeId: { type: String, ref: 'Notice' },
         read: { type: Boolean, default: false }
       }
     ]

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -26,7 +26,7 @@ const userSchema = new Schema<IUser>(
     isVip: { type: Boolean, default: false },
     subscriptions: [{ type: Schema.Types.ObjectId, ref: 'Subscription' }],
     createdAt: { type: Date, default: Date.now },
-    birthday: { type: String, default: '2000-01-01' },
+    birthday: { type: String },
     gender: { type: String, default: '1', enum: ['0', '1'] },
     collects: [{ type: String, ref: 'News' }],
     follows: [{ type: String, ref: 'News' }]

--- a/src/routes/api/v1/adminRouter.ts
+++ b/src/routes/api/v1/adminRouter.ts
@@ -1,8 +1,9 @@
 import express from 'express'
-import { createNewsArticle } from '../../../controllers/adminController'
+import { createNewsArticle, getNoticeList } from '../../../controllers/adminController'
 
 const router = express.Router()
 
+router.get('/notice-list', getNoticeList)
 router.post('/create-news-article', createNewsArticle)
 
 export default router

--- a/src/routes/api/v1/adminRouter.ts
+++ b/src/routes/api/v1/adminRouter.ts
@@ -3,7 +3,60 @@ import { createNewsArticle, getNoticeList } from '../../../controllers/adminCont
 
 const router = express.Router()
 
-router.get('/notice-list', getNoticeList)
-router.post('/create-news-article', createNewsArticle)
+router.get('/notice-list',
+  /*
+    * #swagger.tags= ['Admins']
+    #swagger.description = '取得所有通知訊息列表'
+    #swagger.security = [{'api_key': ['apiKeyAuth']}]
+    #swagger.parameters['pageSize'] = {
+      in: 'query',
+      type: 'String',
+      description: '每頁數量',
+    },
+    #swagger.parameters['pageIndex'] = {
+      in: 'query',
+      type: 'String',
+      description: '當前頁數',
+    },
+    #swagger.responses[200] = {
+      description: '通知訊息列表資訊',
+      schema: { $ref: '#/definitions/noticeList' }
+    }
+  */
+  getNoticeList)
+router.post('/create-news-article',
+  /*
+    * #swagger.tags= ['Admins']
+    #swagger.description = '新增新聞文章'
+    #swagger.security = [{'api_key': ['apiKeyAuth']}]
+    #swagger.parameters['body'] = {
+      in: 'body',
+      type: 'object',
+      required: true,
+      description: '資料格式',
+      schema: {
+        articleId: '文章ID',
+        title: '文章標題',
+        editor: '文章編輯',
+        topics: ['文章標籤'],
+        publishedAt: '文章發布時間',
+        image: '文章圖片',
+        imageDescription: '文章圖片描述',
+        content: '文章內容',
+        source: {
+          name: '文章來源名稱',
+          url: '文章來源網址'
+        }
+      }
+    },
+    #swagger.responses[200] = {
+      description: '新聞文章資訊',
+      schema: {
+        status: true,
+        message: '新增新聞文章成功'
+      }
+    }
+  */
+  createNewsArticle)
 
 export default router

--- a/src/routes/api/v1/adminRouter.ts
+++ b/src/routes/api/v1/adminRouter.ts
@@ -1,0 +1,8 @@
+import express from 'express'
+import { createNewsArticle } from '../../../controllers/adminController'
+
+const router = express.Router()
+
+router.post('/create-news-article', createNewsArticle)
+
+export default router

--- a/src/routes/api/v1/adminRouter.ts
+++ b/src/routes/api/v1/adminRouter.ts
@@ -20,7 +20,7 @@ router.get('/notice-list',
     },
     #swagger.responses[200] = {
       description: '通知訊息列表資訊',
-      schema: { $ref: '#/definitions/noticeList' }
+      schema: { $ref: '#/definitions/allNoticeList' }
     }
   */
   getNoticeList)

--- a/src/routes/api/v1/guestRouter.ts
+++ b/src/routes/api/v1/guestRouter.ts
@@ -25,15 +25,20 @@ router.get(
   /**
     #swagger.tags = ['Guests']
     #swagger.description  = "取得雜誌文章列表分頁"
-    #swagger.parameters['category'] = {
+    #swagger.parameters['pageSize'] = {
       in: 'query',
       type: 'String',
-      description: '雜誌種類',
+      description: '每頁數量',
     },
     #swagger.parameters['pageIndex'] = {
       in: 'query',
       type: 'String',
       description: '當前頁數',
+    },
+    #swagger.parameters['category'] = {
+      in: 'query',
+      type: 'String',
+      description: '雜誌種類',
     },
     #swagger.responses[200] = {
       description: '雜誌文章列表資訊',

--- a/src/routes/api/v1/userRouter.ts
+++ b/src/routes/api/v1/userRouter.ts
@@ -198,6 +198,11 @@ router.get('/collect-page',
     * #swagger.tags= ['Users']
     #swagger.description = '取得收藏列表'
     #swagger.security = [{'api_key': ['apiKeyAuth']}]
+    #swagger.parameters['pageSize'] = {
+      in: 'query',
+      type: 'String',
+      description: '每頁數量',
+    },
     #swagger.parameters['pageIndex'] = {
       in: 'query',
       type: 'String',
@@ -249,9 +254,64 @@ router.delete('/collect-article/:articleId',
     }
   */
   deleteArticleCollect)
-router.get('/notice-list', getUserNoticeList)
-router.patch('/notice/:noticeId', updateUserNoticeRead)
-router.delete('/notice', deleteUserAllNotice)
+router.get('/notice-list',
+  /*
+  * #swagger.tags= ['Users']
+  #swagger.description = '取得會員通知訊息列表'
+  #swagger.security = [{'api_key': ['apiKeyAuth']}]
+  #swagger.parameters['pageSize'] = {
+    in: 'query',
+    type: 'String',
+    description: '每頁數量',
+  },
+  #swagger.parameters['pageIndex'] = {
+    in: 'query',
+    type: 'String',
+    description: '當前頁數',
+  },
+  #swagger.responses[200] = {
+    description: '通知訊息列表資訊',
+    schema: { $ref: '#/definitions/noticeList' }
+  }
+*/
+  getUserNoticeList)
+router.patch('/notice/:noticeId',
+  /*
+    * #swagger.tags= ['Users']
+    #swagger.description = '會員已閱讀此通知訊息'
+    #swagger.security = [{'api_key': ['apiKeyAuth']}]
+    #swagger.parameters['noticeId'] = {
+      in: 'path',
+      description: 'noticeId',
+      required: true,
+      type: 'string'
+    }
+    #swagger.responses[200] = {
+      description: '通知訊息資訊',
+      schema: {
+        status: true,
+        message: '已閱讀通知訊息成功'
+      }
+    }
+  */
+  updateUserNoticeRead)
+router.delete('/notice',
+  /*
+    * #swagger.tags= ['Users']
+    #swagger.description = '會員刪除所有通知訊息'
+    #swagger.security = [{'api_key': ['apiKeyAuth']}]
+    #swagger.responses[200] = {
+      description: '通知訊息資訊',
+      schema: {
+        status: true,
+        data: {
+          notices: []
+        },
+        message: '刪除所有通知訊息成功'
+      }
+    }
+  */
+  deleteUserAllNotice)
 // 訂閱服務
 router.get('/:userId/subscription',
   /*

--- a/src/routes/api/v1/userRouter.ts
+++ b/src/routes/api/v1/userRouter.ts
@@ -10,7 +10,9 @@ import {
   getUserFollowList,
   addArticleFollow,
   deleteArticleFollow,
-  getNoticeList
+  getUserNoticeList,
+  updateUserNoticeRead,
+  deleteUserAllNotice
 } from '../../../controllers/userController'
 import {
   registerUser,
@@ -247,7 +249,9 @@ router.delete('/collect-article/:articleId',
     }
   */
   deleteArticleCollect)
-router.get('/notice-list', getNoticeList)
+router.get('/notice-list', getUserNoticeList)
+router.patch('/notice/:noticeId', updateUserNoticeRead)
+router.delete('/notice', deleteUserAllNotice)
 // 訂閱服務
 router.get('/:userId/subscription',
   /*

--- a/src/routes/api/v1/userRouter.ts
+++ b/src/routes/api/v1/userRouter.ts
@@ -9,7 +9,8 @@ import {
   deleteArticleCollect,
   getUserFollowList,
   addArticleFollow,
-  deleteArticleFollow
+  deleteArticleFollow,
+  getNoticeList
 } from '../../../controllers/userController'
 import {
   registerUser,
@@ -246,6 +247,7 @@ router.delete('/collect-article/:articleId',
     }
   */
   deleteArticleCollect)
+router.get('/notice-list', getNoticeList)
 // 訂閱服務
 router.get('/:userId/subscription',
   /*

--- a/src/routes/api/v1/userRouter.ts
+++ b/src/routes/api/v1/userRouter.ts
@@ -271,7 +271,7 @@ router.get('/notice-list',
   },
   #swagger.responses[200] = {
     description: '通知訊息列表資訊',
-    schema: { $ref: '#/definitions/noticeList' }
+    schema: { $ref: '#/definitions/userNoticeList' }
   }
 */
   getUserNoticeList)

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -4,6 +4,7 @@ import memberRouter from './api/v1/memberRouter'
 import guestRouter from './api/v1/guestRouter'
 import uploadRouter from './api/v1/uploadRouter'
 import orderRouter from './api/v1/orderRouter'
+import adminRouter from './api/v1/adminRouter'
 import { authenticate, vipVerify } from '../middleware/authMiddleware'
 
 const routes = Router()
@@ -13,6 +14,6 @@ routes.use('/api/v1/user', userRouter) // 一般使用者
 routes.use('/api/v1/upload', authenticate, uploadRouter) // 上傳照片、取得照片列表
 routes.use('/api/v1/member', authenticate, vipVerify, memberRouter) // 訂閱使用者
 routes.use('/api/v1/order', orderRouter) // 金流相關
-// routes.use('/api/v1/admin', authenticate, adminRouter)// 後台管理者
+routes.use('/api/v1/admin', adminRouter)// 後台管理者
 
 export default routes

--- a/src/utils/notice.ts
+++ b/src/utils/notice.ts
@@ -1,0 +1,54 @@
+import { getSocektIo, getOnlineUsers } from '../connections/socket'
+import User, { IUser } from '../models/User'
+import Notice from '../models/Notice'
+import { INews } from '../models/News'
+
+// 發布通知
+const postNotice = async (updates: string[], title?: string) => {
+  updates.forEach((uid: string) => {
+    const userId = uid.toString()
+    const socketId = getOnlineUsers()[userId]
+    if (socketId) {
+      getSocektIo().to(socketId).emit('notice', {
+        action: 'create',
+        receive: true,
+        title
+      })
+    }
+  })
+}
+
+// 使用者系統通知
+export const postSystemNotice = async (data: any, userId: string) => {
+  const newNotice = await Notice.create({
+    title: data.title,
+    content: data.content,
+    publishedAt: data.publishedAt
+  })
+
+  await User.findByIdAndUpdate(userId, {
+    $addToSet: { notices: { noticeId: newNotice._id } }
+  })
+  postNotice([userId], newNotice.title)
+}
+
+// 使用者追蹤通知
+export const postFollowNotice = async (data: INews) => {
+  const newNotice = await Notice.create({
+    articleId: data.articleId,
+    topic: data.topic,
+    title: data.title,
+    content: data.content,
+    publishedAt: data.publishedAt
+  })
+
+  const users = await User.find({ follows: { $in: data.topic } })
+
+  const updates = users.map((user: IUser) => user._id)
+
+  await User.updateMany(
+    { _id: { $in: updates } },
+    { $addToSet: { notices: { noticeId: newNotice._id } } }
+  )
+  postNotice(updates, newNotice.title)
+}

--- a/swagger.js
+++ b/swagger.js
@@ -134,7 +134,7 @@ const doc = {
         ]
       }
     },
-    noticeList: {
+    allNoticeList: {
       status: true,
       message: '取得通知訊息列表成功',
       data: {
@@ -148,6 +148,29 @@ const doc = {
             publishedAt: '文章發布時間'
           }
         ],
+        firstPage: '是否為第一頁',
+        lastPage: '是否為最後一頁',
+        empty: '是否沒有資料',
+        totalElement: '總共有幾筆資料',
+        totalPages: '總共有幾頁',
+        targetPage: '目前在第幾頁'
+      }
+    },
+    userNoticeList: {
+      status: true,
+      message: '取得通知訊息列表成功',
+      data: {
+        notices: [
+          {
+            id: '通知ID',
+            articleId: '文章ID',
+            title: '文章標題',
+            editor: '文章編輯',
+            topics: ['文章標籤'],
+            publishedAt: '文章發布時間'
+          }
+        ],
+        unreadElements: '未讀通知數量',
         firstPage: '是否為第一頁',
         lastPage: '是否為最後一頁',
         empty: '是否沒有資料',

--- a/swagger.js
+++ b/swagger.js
@@ -133,6 +133,28 @@ const doc = {
           }
         ]
       }
+    },
+    noticeList: {
+      status: true,
+      message: '取得通知訊息列表成功',
+      data: {
+        notices: [
+          {
+            id: '通知ID',
+            articleId: '文章ID',
+            title: '文章標題',
+            editor: '文章編輯',
+            topics: ['文章標籤'],
+            publishedAt: '文章發布時間'
+          }
+        ],
+        firstPage: '是否為第一頁',
+        lastPage: '是否為最後一頁',
+        empty: '是否沒有資料',
+        totalElement: '總共有幾筆資料',
+        totalPages: '總共有幾頁',
+        targetPage: '目前在第幾頁'
+      }
     }
   }
 }

--- a/swagger_output.json
+++ b/swagger_output.json
@@ -5,7 +5,7 @@
     "title": "REST API",
     "description": ""
   },
-  "host": "localhost:3000",
+  "host": "localhost:5173",
   "basePath": "/",
   "tags": [
     {
@@ -695,7 +695,7 @@
           "200": {
             "description": "通知訊息列表資訊",
             "schema": {
-              "$ref": "#/definitions/noticeList"
+              "$ref": "#/definitions/userNoticeList"
             }
           }
         },
@@ -1396,7 +1396,7 @@
           "200": {
             "description": "通知訊息列表資訊",
             "schema": {
-              "$ref": "#/definitions/noticeList"
+              "$ref": "#/definitions/allNoticeList"
             }
           }
         },
@@ -1785,7 +1785,7 @@
         }
       }
     },
-    "noticeList": {
+    "allNoticeList": {
       "type": "object",
       "properties": {
         "status": {
@@ -1835,6 +1835,89 @@
                   }
                 }
               }
+            },
+            "firstPage": {
+              "type": "string",
+              "example": "是否為第一頁"
+            },
+            "lastPage": {
+              "type": "string",
+              "example": "是否為最後一頁"
+            },
+            "empty": {
+              "type": "string",
+              "example": "是否沒有資料"
+            },
+            "totalElement": {
+              "type": "string",
+              "example": "總共有幾筆資料"
+            },
+            "totalPages": {
+              "type": "string",
+              "example": "總共有幾頁"
+            },
+            "targetPage": {
+              "type": "string",
+              "example": "目前在第幾頁"
+            }
+          }
+        }
+      }
+    },
+    "userNoticeList": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "type": "boolean",
+          "example": true
+        },
+        "message": {
+          "type": "string",
+          "example": "取得通知訊息列表成功"
+        },
+        "data": {
+          "type": "object",
+          "properties": {
+            "notices": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "example": "通知ID"
+                  },
+                  "articleId": {
+                    "type": "string",
+                    "example": "文章ID"
+                  },
+                  "title": {
+                    "type": "string",
+                    "example": "文章標題"
+                  },
+                  "editor": {
+                    "type": "string",
+                    "example": "文章編輯"
+                  },
+                  "topics": {
+                    "type": "array",
+                    "example": [
+                      "文章標籤"
+                    ],
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "publishedAt": {
+                    "type": "string",
+                    "example": "文章發布時間"
+                  }
+                }
+              }
+            },
+            "unreadElements": {
+              "type": "string",
+              "example": "未讀通知數量"
             },
             "firstPage": {
               "type": "string",

--- a/swagger_output.json
+++ b/swagger_output.json
@@ -69,16 +69,22 @@
         "description": "取得雜誌文章列表分頁",
         "parameters": [
           {
-            "name": "category",
+            "name": "pageSize",
             "in": "query",
             "type": "String",
-            "description": "雜誌種類"
+            "description": "每頁數量"
           },
           {
             "name": "pageIndex",
             "in": "query",
             "type": "String",
             "description": "當前頁數"
+          },
+          {
+            "name": "category",
+            "in": "query",
+            "type": "String",
+            "description": "雜誌種類"
           }
         ],
         "responses": {
@@ -548,6 +554,12 @@
         "description": "取得收藏列表",
         "parameters": [
           {
+            "name": "pageSize",
+            "in": "query",
+            "type": "String",
+            "description": "每頁數量"
+          },
+          {
             "name": "pageIndex",
             "in": "query",
             "type": "String",
@@ -642,6 +654,134 @@
                 "message": {
                   "type": "string",
                   "example": "取消收藏文章成功"
+                }
+              },
+              "xml": {
+                "name": "main"
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": [
+              "apiKeyAuth"
+            ]
+          }
+        ]
+      }
+    },
+    "/api/v1/user/notice-list": {
+      "get": {
+        "tags": [
+          "Users"
+        ],
+        "description": "取得會員通知訊息列表",
+        "parameters": [
+          {
+            "name": "pageSize",
+            "in": "query",
+            "type": "String",
+            "description": "每頁數量"
+          },
+          {
+            "name": "pageIndex",
+            "in": "query",
+            "type": "String",
+            "description": "當前頁數"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "通知訊息列表資訊",
+            "schema": {
+              "$ref": "#/definitions/noticeList"
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": [
+              "apiKeyAuth"
+            ]
+          }
+        ]
+      }
+    },
+    "/api/v1/user/notice/{noticeId}": {
+      "patch": {
+        "tags": [
+          "Users"
+        ],
+        "description": "會員已閱讀此通知訊息",
+        "parameters": [
+          {
+            "name": "noticeId",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "noticeId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "通知訊息資訊",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "boolean",
+                  "example": true
+                },
+                "message": {
+                  "type": "string",
+                  "example": "已閱讀通知訊息成功"
+                }
+              },
+              "xml": {
+                "name": "main"
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": [
+              "apiKeyAuth"
+            ]
+          }
+        ]
+      }
+    },
+    "/api/v1/user/notice": {
+      "delete": {
+        "tags": [
+          "Users"
+        ],
+        "description": "會員刪除所有通知訊息",
+        "responses": {
+          "200": {
+            "description": "通知訊息資訊",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "boolean",
+                  "example": true
+                },
+                "data": {
+                  "type": "object",
+                  "properties": {
+                    "notices": {
+                      "type": "array",
+                      "example": [],
+                      "items": {}
+                    }
+                  }
+                },
+                "message": {
+                  "type": "string",
+                  "example": "刪除所有通知訊息成功"
                 }
               },
               "xml": {
@@ -1231,6 +1371,142 @@
           }
         ]
       }
+    },
+    "/api/v1/admin/notice-list": {
+      "get": {
+        "tags": [
+          "Admins"
+        ],
+        "description": "取得所有通知訊息列表",
+        "parameters": [
+          {
+            "name": "pageSize",
+            "in": "query",
+            "type": "String",
+            "description": "每頁數量"
+          },
+          {
+            "name": "pageIndex",
+            "in": "query",
+            "type": "String",
+            "description": "當前頁數"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "通知訊息列表資訊",
+            "schema": {
+              "$ref": "#/definitions/noticeList"
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": [
+              "apiKeyAuth"
+            ]
+          }
+        ]
+      }
+    },
+    "/api/v1/admin/create-news-article": {
+      "post": {
+        "tags": [
+          "Admins"
+        ],
+        "description": "新增新聞文章",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "description": "資料格式",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "articleId": {
+                  "type": "string",
+                  "example": "文章ID"
+                },
+                "title": {
+                  "type": "string",
+                  "example": "文章標題"
+                },
+                "editor": {
+                  "type": "string",
+                  "example": "文章編輯"
+                },
+                "topics": {
+                  "type": "array",
+                  "example": [
+                    "文章標籤"
+                  ],
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "publishedAt": {
+                  "type": "string",
+                  "example": "文章發布時間"
+                },
+                "image": {
+                  "type": "string",
+                  "example": "文章圖片"
+                },
+                "imageDescription": {
+                  "type": "string",
+                  "example": "文章圖片描述"
+                },
+                "content": {
+                  "type": "string",
+                  "example": "文章內容"
+                },
+                "source": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "example": "文章來源名稱"
+                    },
+                    "url": {
+                      "type": "string",
+                      "example": "文章來源網址"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "新聞文章資訊",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "boolean",
+                  "example": true
+                },
+                "message": {
+                  "type": "string",
+                  "example": "新增新聞文章成功"
+                }
+              },
+              "xml": {
+                "name": "main"
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": [
+              "apiKeyAuth"
+            ]
+          }
+        ]
+      }
     }
   },
   "definitions": {
@@ -1504,6 +1780,85 @@
                   }
                 }
               }
+            }
+          }
+        }
+      }
+    },
+    "noticeList": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "type": "boolean",
+          "example": true
+        },
+        "message": {
+          "type": "string",
+          "example": "取得通知訊息列表成功"
+        },
+        "data": {
+          "type": "object",
+          "properties": {
+            "notices": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "example": "通知ID"
+                  },
+                  "articleId": {
+                    "type": "string",
+                    "example": "文章ID"
+                  },
+                  "title": {
+                    "type": "string",
+                    "example": "文章標題"
+                  },
+                  "editor": {
+                    "type": "string",
+                    "example": "文章編輯"
+                  },
+                  "topics": {
+                    "type": "array",
+                    "example": [
+                      "文章標籤"
+                    ],
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "publishedAt": {
+                    "type": "string",
+                    "example": "文章發布時間"
+                  }
+                }
+              }
+            },
+            "firstPage": {
+              "type": "string",
+              "example": "是否為第一頁"
+            },
+            "lastPage": {
+              "type": "string",
+              "example": "是否為最後一頁"
+            },
+            "empty": {
+              "type": "string",
+              "example": "是否沒有資料"
+            },
+            "totalElement": {
+              "type": "string",
+              "example": "總共有幾筆資料"
+            },
+            "totalPages": {
+              "type": "string",
+              "example": "總共有幾頁"
+            },
+            "targetPage": {
+              "type": "string",
+              "example": "目前在第幾頁"
             }
           }
         }


### PR DESCRIPTION
1. 新增新聞文章api (管理者) & 追蹤使用者發布通知  POST /admin/create-news-article
2. 取得所有通知訊息 api (管理者) GET /admin/notice-list
3. 取得會員通知訊息列表 api (會員) GET /user/notice-list
4. 會員已閱讀此通知訊息 api (會員) PATCH /user/notice/{{noticeId}}
5. 刪除會員所有通知訊息 api (會員) DELETE /user/notice
6. 可發布系統通知 (fn: postSystemNotice) 例如: 註冊成功也可以發送註冊成功通知給使用者
7. 根據使用者發布、接收通知訊息