### PR TITLE
feat(ecPay-7): 調整綠界金流訂單邏輯

### DIFF
--- a/src/controllers/subscriptionController.ts
+++ b/src/controllers/subscriptionController.ts
@@ -3,44 +3,8 @@ import User from '../models/User'
 import Subscription from '../models/Subscription'
 import { catchAsync } from '../utils/catchAsync'
 import { appSuccess } from '../utils/appSuccess'
-import { appError } from '../middleware/errorMiddleware'
-import { apiState } from '../utils/apiState'
-
-// 加入訂閱
-const addSubscription = catchAsync(async (req: Request, res: Response, next: NextFunction) => {
-  const { userId } = req.params
-  const { plan, duration } = req.body
-
-  // 計算訂閱到期日
-  let expiryDate: Date
-  if (duration === 'month') {
-    expiryDate = new Date(new Date().setMonth(new Date().getMonth() + 1))
-  } else if (duration === 'year') {
-    expiryDate = new Date(new Date().setFullYear(new Date().getFullYear() + 1))
-  } else {
-    return appError(apiState.ID_ERROR, next)
-  }
-
-  // 創建新的訂閱
-  const subscription = new Subscription({
-    plan,
-    subscriptionDate: new Date(),
-    expiryDate,
-    duration
-  })
-  await subscription.save()
-
-  // 查找用戶並添加訂閱
-  const user = await User.findById(userId)
-  if (!user) {
-    return appError(apiState.DATA_NOT_FOUND, next)
-  }
-
-  user.subscriptions.unshift(subscription._id)
-  await user.save()
-
-  appSuccess({ res, message: '訂閱成功' })
-})
+// import { appError } from '../middleware/errorMiddleware'
+// import { apiState } from '../utils/apiState'
 
 const getSubscription = catchAsync(async (req: Request, res: Response, next: NextFunction) => {
   const { userId } = req.params
@@ -73,4 +37,4 @@ const toggleRenewal = catchAsync(async (req: Request, res: Response, next: NextF
   appSuccess({ res, data: data.autoRenew, message: '狀態更新成功' })
 })
 
-export { addSubscription, getSubscription, toggleRenewal }
+export { getSubscription, toggleRenewal }

--- a/src/models/Order.ts
+++ b/src/models/Order.ts
@@ -7,6 +7,7 @@ export interface IOrder extends Document {
   transactionId: string;
   total: number;
   payStatus: string;
+  orderAt: Date;
   paidAt: Date;
 }
 
@@ -42,6 +43,7 @@ const orderSchema = new Schema<IOrder>(
       required: true,
       default: 'unpaid'
     },
+    orderAt: { type: Date },
     paidAt: {
       // 付款時間
       type: Date

--- a/src/routes/api/v1/userRouter.ts
+++ b/src/routes/api/v1/userRouter.ts
@@ -16,7 +16,7 @@ import {
   authenticateUser,
   logoutUser
 } from '../../../controllers/authController'
-import { addSubscription, getSubscription, toggleRenewal } from '../../../controllers/subscriptionController'
+import { getSubscription, toggleRenewal } from '../../../controllers/subscriptionController'
 import { authenticate } from '../../../middleware/authMiddleware'
 
 export const router = express.Router()
@@ -264,26 +264,7 @@ router.get('/:userId/subscription',
       }
     */
   getSubscription)
-router.post('/:userId/subscription',
-  /*
-      * #swagger.tags= ['Users']
-      #swagger.description = '訂閱服務'
-      #swagger.security = [{'api_key': ['apiKeyAuth']}]
-      #swagger.parameters['userId'] = {
-        in: 'path',
-        description: 'userId',
-        required: true,
-        type: 'string'
-      }
-      #swagger.responses[200] = {
-        description: '訂閱成功',
-        schema: {
-          status: true,
-          message: '訂閱成功'
-        }
-      }
-    */
-  addSubscription)
+
 router.patch('/:subscriptionId/subscription/renew',
   /*
     * #swagger.tags= ['Users']

--- a/swagger_output.json
+++ b/swagger_output.json
@@ -689,64 +689,6 @@
             ]
           }
         ]
-      },
-      "post": {
-        "tags": [
-          "Users"
-        ],
-        "description": "訂閱服務",
-        "parameters": [
-          {
-            "name": "userId",
-            "in": "path",
-            "required": true,
-            "type": "string",
-            "description": "userId"
-          },
-          {
-            "name": "body",
-            "in": "body",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "plan": {
-                  "example": "any"
-                },
-                "duration": {
-                  "example": "any"
-                }
-              }
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "訂閱成功",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "status": {
-                  "type": "boolean",
-                  "example": true
-                },
-                "message": {
-                  "type": "string",
-                  "example": "訂閱成功"
-                }
-              },
-              "xml": {
-                "name": "main"
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "api_key": [
-              "apiKeyAuth"
-            ]
-          }
-        ]
       }
     },
     "/api/v1/user/{subscriptionId}/subscription/renew": {
@@ -1199,6 +1141,12 @@
                   "example": "any"
                 },
                 "RtnCode": {
+                  "example": "any"
+                },
+                "CustomField1": {
+                  "example": "any"
+                },
+                "CustomField2": {
                   "example": "any"
                 }
               }


### PR DESCRIPTION
1. model 新增 OrderAt，表示訂單成立時間

2. ClientBackURL 補上訂單編號，讓前端可以透過編號抓取單訂單資料

3. 若付款成功時，修改 user 的狀態: isVip、planType、subscribeExpiredAt

4. 移除 addSubscription，後續都改用金流成立訂閱訂單