### PR TITLE
feat(ecPay-8): 完成綠界金流串接

### DIFF
--- a/src/controllers/authController.ts
+++ b/src/controllers/authController.ts
@@ -51,7 +51,7 @@ const authenticateUser = async (req: Request, res: Response) => {
   const user = await User.findOne({ email })
 
   if (!user || !(await user.comparePassword(password))) {
-    return res.status(401).json({ status: false, message: '找不到使用者 / 密碼錯誤' })
+    return res.status(400).json({ status: false, message: '找不到使用者 / 密碼錯誤' })
   }
   const token = generateToken(res, user._id)
   res.status(200).json({

--- a/src/controllers/orderController.ts
+++ b/src/controllers/orderController.ts
@@ -81,18 +81,20 @@ const getPaymentResults = catchAsync(async (req:Request, res:Response, next:Next
 
   // 比對綠界回傳的檢查碼是否一致，若綠界未收到 1|OK ，隔5~15分鐘後重發訊息，共四次
   if (CheckMacValue === checkValue) {
-    const isPaidSuccess = RtnCode === '1'
     // 付款成功: '1'
+    const isPaidSuccess = RtnCode === '1'
+    // 到期日
+    const subscribeExpiredAt = CustomField2 === 'month' ? moment(PaymentDate).add(30, 'days') : moment(PaymentDate).add(365, 'days')
     const updateDate = isPaidSuccess
       ? {
           payStatus: 'paid',
           orderAt: moment(TradeDate),
-          paidAt: moment(PaymentDate)
+          paidAt: moment(PaymentDate),
+          subscribeExpiredAt
         }
       : {
           payStatus: 'failed'
         }
-
     await Order.updateOne(
       {
         userId: CustomField1,
@@ -107,7 +109,7 @@ const getPaymentResults = catchAsync(async (req:Request, res:Response, next:Next
         {
           isVip: true,
           planType: CustomField2,
-          subscribeExpiredAt: CustomField2 === 'month' ? moment(PaymentDate).add(30, 'days') : moment(PaymentDate).add(365, 'days')
+          subscribeExpiredAt
         }
       )
     }

--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -13,7 +13,7 @@ const topics = ['國際', '社會', '科技', '財經', '體育', '娛樂']
 // 取得會員狀態資料
 const getUser = catchAsync(async (req: Request, res: Response, next: NextFunction) => {
   const userId = req.user?._id
-  const user = await User.findById(userId, 'name avatar email isVip subscribeExpiredAt collects follows')
+  const user = await User.findById(userId, 'name avatar email isVip subscribeExpiredAt collects follows planType')
 
   if (!user) {
     return appError({ statusCode: 401, message: '登入發生錯誤，請稍候再嘗試' }, next)

--- a/src/models/Order.ts
+++ b/src/models/Order.ts
@@ -9,6 +9,7 @@ export interface IOrder extends Document {
   payStatus: string;
   orderAt: Date;
   paidAt: Date;
+  subscribeExpiredAt: Date;
 }
 
 const orderSchema = new Schema<IOrder>(
@@ -46,6 +47,9 @@ const orderSchema = new Schema<IOrder>(
     orderAt: { type: Date },
     paidAt: {
       // 付款時間
+      type: Date
+    },
+    subscribeExpiredAt: {
       type: Date
     }
   },

--- a/src/routes/api/v1/userRouter.ts
+++ b/src/routes/api/v1/userRouter.ts
@@ -247,17 +247,16 @@ router.delete('/collect-article/:articleId',
   */
   deleteArticleCollect)
 // 訂閱服務
-router.get('/:userId/subscription',
+router.get('/subscription',
   /*
     * #swagger.tags= ['Users']
-      #swagger.description = '查詢用戶訂閱狀態'
+      #swagger.description = '查詢用戶訂單記錄'
       #swagger.security = [{'api_key': ['apiKeyAuth']}]
-      #swagger.parameters['userId'] = {
-        in: 'path',
-        description: 'userId',
-        required: true,
-        type: 'string'
-      }
+      #swagger.parameters['transactionId'] = {
+        in: 'query',
+        type: 'String',
+        description: '訂單編號',
+      },
       #swagger.responses[200] = {
         description: '成功返回用戶的訂閱狀態',
         schema: {$ref: '#/definitions/subscriptionInfo'}


### PR DESCRIPTION
1. 付款成功 時，order model 加上到期日，一併更新 user model 的到期日

2. 調整取得訂閱訂單記錄的 api，篩選該用戶特定訂單資料，無篩選則給全部，前端會用來呈現付款頁第三步 & 訂閱管理頁

3. 取得會員狀態補上 planType 供前端使用

4. 調整登入錯誤狀態碼改為 400，401 前端會跳出未授權提示