### PR TITLE
feat(comment): 調整留言功能

### DIFF
--- a/src/controllers/guestController.ts
+++ b/src/controllers/guestController.ts
@@ -108,7 +108,8 @@ const getArticleDetail = catchAsync(async (req: Request, res: Response, next: Ne
 
 // 取得文章留言列表
 const getArticleCommentList = catchAsync(async (req: Request, res: Response, next: NextFunction) => {
-  const { id } = req.params
+  const userId = req.user?._id
+  const { articleId } = req.params
   const { pageIndex, pageSize } = req.query
 
   const pageIndexNumber = pageIndex !== undefined && pageIndex !== ''
@@ -120,16 +121,20 @@ const getArticleCommentList = catchAsync(async (req: Request, res: Response, nex
     : 10
 
   const [totalElements, comments] = await Promise.all([
-    Comment.countDocuments({ article: id }),
-    Comment.find({ article: id })
-      .populate({
+    Comment.countDocuments({ articleId }),
+    Comment.find({ articleId })
+      .populate([{
         path: 'user',
         select: '-_id name avatar'
-      })
-      .sort({ publishedAt: -1 })
+      }, {
+        path: 'userId',
+        match: { _id: { $eq: userId } },
+        select: '_id'
+      }])
+      .sort({ createdAt: -1 })
       .skip((pageIndexNumber - 1) * pageSizeNumber)
       .limit(pageSizeNumber)
-      .select('-article')
+      .select('-article -articleId -createdAt')
   ])
 
   const firstPage = pageIndexNumber === 1

--- a/src/models/Comment.ts
+++ b/src/models/Comment.ts
@@ -2,16 +2,22 @@ import mongoose, { Document, Schema } from 'mongoose'
 
 export interface IComment extends Document {
   user: mongoose.Types.ObjectId;
-  article: string;
+  userId: mongoose.Types.ObjectId;
+  article: mongoose.Types.ObjectId;
+  articleId: string;
   content: string;
   publishedAt: string;
+  createdAt: Date
 }
 
 const commentSchema = new Schema<IComment>(
   {
     user: { type: mongoose.Schema.ObjectId, ref: 'User', required: true },
-    article: { type: String, ref: 'New', required: true },
+    userId: { type: mongoose.Schema.ObjectId, ref: 'User', required: true },
+    article: { type: mongoose.Schema.ObjectId, ref: 'New', required: true },
+    articleId: { type: String, ref: 'New', required: true },
     content: { type: String, required: true },
+    createdAt: { type: Date, default: Date.now },
     publishedAt: { type: String, required: true }
   },
   {

--- a/src/routes/api/v1/guestRouter.ts
+++ b/src/routes/api/v1/guestRouter.ts
@@ -6,6 +6,7 @@ import {
   getHotNewsList,
   getArticleCommentList
 } from '../../../controllers/guestController'
+import { getUserId } from '../../../middleware/authMiddleware'
 
 const router = express.Router()
 
@@ -89,14 +90,14 @@ router.get('/hot-news-list'
       }
   */
   , getHotNewsList)
-router.get('/article-comment-page/:id',
+router.get('/article-comment-page/:articleId', getUserId
   /*
     #swagger.tags= ['Guests']
     #swagger.description = '取得文章留言列表'
     #swagger.security = [{'api_key': ['apiKeyAuth']}]
-    #swagger.parameters['id'] = {
+    #swagger.parameters['articleId'] = {
       in: 'path',
-      description: '文章UID',
+      description: '文章ID',
       required: true,
       type: 'string'
     }
@@ -115,5 +116,5 @@ router.get('/article-comment-page/:id',
       schema: { $ref: '#/definitions/guestCommentList' }
     }
   */
-  getArticleCommentList)
+  , getArticleCommentList)
 export default router

--- a/src/routes/api/v1/userRouter.ts
+++ b/src/routes/api/v1/userRouter.ts
@@ -343,14 +343,14 @@ router.get('/article-comment-page',
     }
   */
   getUserCommentList)
-router.post('/article-comment/:id',
+router.post('/article-comment/:articleId',
   /*
     #swagger.tags= ['Users']
     #swagger.description = '新增會員留言'
     #swagger.security = [{'api_key': ['apiKeyAuth']}]
-    #swagger.parameters['id'] = {
+    #swagger.parameters['articleId'] = {
       in: 'path',
-      description: '文章UID',
+      description: '文章ID',
       required: true,
       type: 'string'
     }
@@ -369,14 +369,14 @@ router.post('/article-comment/:id',
     }
   */
   createUserComment)
-router.delete('/article-comment/:id',
+router.delete('/article-comment/:commentId',
   /*
     #swagger.tags= ['Users']
-    #swagger.description = '新增會員留言'
+    #swagger.description = '刪除會員留言'
     #swagger.security = [{'api_key': ['apiKeyAuth']}]
-    #swagger.parameters['id'] = {
+    #swagger.parameters['commentId'] = {
       in: 'path',
-      description: '文章UID',
+      description: '留言UID',
       required: true,
       type: 'string'
     }

--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -5,5 +5,6 @@ export function formatToDate () {
   const day = isoDate.getDate().toString().padStart(2, '0')
   const hours = isoDate.getHours().toString().padStart(2, '0')
   const minutes = isoDate.getMinutes().toString().padStart(2, '0')
-  return `${year}-${month}-${day} ${hours}:${minutes}`
+  const seconds = isoDate.getSeconds().toString().padStart(2, '0')
+  return `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`
 }

--- a/swagger_output.json
+++ b/swagger_output.json
@@ -5,7 +5,7 @@
     "title": "REST API",
     "description": ""
   },
-  "host": "localhost:5173",
+  "host": "localhost:3000",
   "basePath": "/",
   "tags": [
     {
@@ -147,7 +147,7 @@
         }
       }
     },
-    "/api/v1/guest/article-comment-page/{id}": {
+    "/api/v1/guest/article-comment-page/{articleId}": {
       "get": {
         "tags": [
           "Guests"
@@ -155,11 +155,11 @@
         "description": "取得文章留言列表",
         "parameters": [
           {
-            "name": "id",
+            "name": "articleId",
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "文章UID"
+            "description": "文章ID"
           },
           {
             "name": "pageSize",
@@ -879,7 +879,7 @@
         ]
       }
     },
-    "/api/v1/user/article-comment/{id}": {
+    "/api/v1/user/article-comment/{articleId}": {
       "post": {
         "tags": [
           "Users"
@@ -887,11 +887,11 @@
         "description": "新增會員留言",
         "parameters": [
           {
-            "name": "id",
+            "name": "articleId",
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "文章UID"
+            "description": "文章ID"
           },
           {
             "name": "body",
@@ -935,19 +935,21 @@
             ]
           }
         ]
-      },
+      }
+    },
+    "/api/v1/user/article-comment/{commentId}": {
       "delete": {
         "tags": [
           "Users"
         ],
-        "description": "新增會員留言",
+        "description": "刪除會員留言",
         "parameters": [
           {
-            "name": "id",
+            "name": "commentId",
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "文章UID"
+            "description": "留言UID"
           }
         ],
         "responses": {
@@ -1151,7 +1153,7 @@
         "tags": [
           "Users"
         ],
-        "description": "取得雜誌文章詳情",
+        "description": "取得免費閱讀雜誌文章詳情",
         "parameters": [
           {
             "name": "articleId",


### PR DESCRIPTION
調整:

1. comment model

(1) 加上 userId，for 文章內頁判斷該留言是否是該登入會員

(2) article 改為關聯 News

(3) articleId 為 News 內的 articleId

(4) 用 publishedAt 排序可能會有問題故改用 createdAt

2. 調整 api params 命名較好識別

3. guest/getArticleCommentList

(1) 文章 id 改為接收 articleId 而非 Mongo DB 的 id　（因前台不會知道文章的 Mongo DB id）

(2) 前台文章詳情的留言區需要判斷該留言者是否為會員本人，利用會員 id
判斷，故在 authMiddleware 加上 getUserId 取得 request 是來自哪個會員，但不強制驗證身份

4. user/getUserCommentList

(1) 文章不顯示內容 （避免非訂閱用戶顯示雜誌文章）

5. user/createUserComment

(1) 文章 id 改為接收 articleId 而非 Mongo DB 的 id（因前台不會知道文章的 Mongo DB id）

(2) 存取 userId、articleId、article